### PR TITLE
Fix typo in property name for restless sleep time

### DIFF
--- a/3_2-SleepResources-typo
+++ b/3_2-SleepResources-typo
@@ -86,7 +86,7 @@ away_episode_count | Number of absences during the night
 total_snoring_episode_duration | Total amount of snoring, in seconds
 stage_duration_A | Total time in away state in the measurement period, in seconds
 stage_duration_S | Total time in sleep state in the measurement period
-stage_duration_S | Total time in restless sleep state in the measurement period
+stage_duration_R | Total time in restless sleep state in the measurement period
 stage_duration_W | Total time in wake state in the measurement period
 stage_duration_N | Total amount of "no signal" time in the measurement period
 stage_duration_G | Total amount of "gap" time in the measurement period


### PR DESCRIPTION
stage_duration_S was duplicated, I haven't used the API yet but I'm guessing stage_duration_R is correct for restless sleep.